### PR TITLE
Ship collision detection proposal

### DIFF
--- a/ship_class.py
+++ b/ship_class.py
@@ -89,14 +89,26 @@ class Navi:
         else:
             return False
         
+    def crashes_against(self, altra_nave):
+        """Indicates whether a ship crashes against another one
+        Parameters:
+          @altra_nave: the other ship
 
+        Returns:
+          True in case of crash, False otherwise
+        """
+        pass
     
+    def __get_boundaries(self):
+        """Returns a tuple containing the (topLeft, bottomRight) corners of the rectangle surrounding the ship
+        Returns:
+          The (topLeft, bottomRight) tuple, e.g.: for a 4len vertical ship in B2 the returned boundaries are ((1, 0), (6, 2))
+        """
+        pass
     
-                     
-
-
-
-
-                     
-
-
+    def __get_used_cells(self):
+        """Returns a list of cells used by the ship
+        Returns:
+          The list of used cells, e.g.: for a 4len vertical ship in B2 the list is [(2, 1), (3, 1), (4, 1), (5, 1)]
+        """
+        pass

--- a/test_ship.py
+++ b/test_ship.py
@@ -1,0 +1,74 @@
+import unittest
+
+from ship_class import Navi
+
+class TestShip(unittest.TestCase):
+    def test_consecutive_horizontal_5len_5len_ships_crash(self):
+        first_ship = Navi('first', 5, 'o', 0, 'A', None)
+        second_ship = Navi('second', 5, 'o', 0, 'F', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))
+
+    def test_consecutive_horizontal_5len_1len_ships_crash(self):
+        first_ship = Navi('first', 5, 'o', 0, 'A', None)
+        second_ship = Navi('second', 1, 'o', 0, 'F', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))
+
+    def test_parallel_horizontal_5len_ships_separated_by_one_row_dont_crash(self):
+        first_ship = Navi('first', 5, 'o', 3, 'A', None)
+        second_ship = Navi('second', 5, 'o', 5, 'F', None)
+        self.assertFalse(first_ship.crashes_against(second_ship))
+
+    def test_completely_overlapped_horizontal_5len_ships_crash(self):
+        first_ship = Navi('first', 5, 'o', 3, 'C', None)
+        second_ship = Navi('second', 5, 'o', 3, 'C', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))        
+
+    def test_completely_overlapped_5len_ships_crash(self):
+        first_ship = Navi('first', 5, 'o', 3, 'C', None)
+        second_ship = Navi('second', 5, 'o', 3, 'C', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))        
+
+    def test_partially_overlapped_5len_ships_crash(self):
+        first_ship = Navi('first', 5, 'o', 3, 'C', None)
+        second_ship = Navi('second', 5, 'o', 3, 'F', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))   
+
+    def test_consecutive_vertical_5len_5len_ships_crash(self):
+        first_ship = Navi('first', 5, 'v', 0, 'E', None)
+        second_ship = Navi('second', 5, 'v', 5, 'E', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))
+
+    def test_consecutive_vertical_5len_horizontal_5len_ships_crash(self):
+        first_ship = Navi('first', 5, 'v', 0, 'E', None)
+        second_ship = Navi('second', 5, 'o', 5, 'F', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))
+
+    def test_parallel_adjacent_5len_vertical_ships_crash(self):
+        first_ship = Navi('first', 5, 'v', 0, 'E', None)
+        second_ship = Navi('second', 5, 'v', 0, 'F', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))
+
+    def test_parallel_adjacent_1len_vertical_ships_crash(self):
+        first_ship = Navi('first', 1, 'v', 0, 'E', None)
+        second_ship = Navi('second', 1, 'v', 0, 'F', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))
+
+    def test_parallel_adjacent_1len_vertical_ships_crash(self):
+        first_ship = Navi('first', 1, 'v', 0, 'E', None)
+        second_ship = Navi('second', 1, 'v', 0, 'F', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))
+
+    def test_diagonal_1len_adjacent_ships_crash(self):
+        first_ship = Navi('first', 1, 'v', 0, 'E', None)
+        second_ship = Navi('second', 1, 'v', 1, 'F', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))
+
+    def test_diagonal_1len_non_adjacent_ships_crash(self):
+        first_ship = Navi('first', 1, 'v', 0, 'E', None)
+        second_ship = Navi('second', 1, 'v', 2, 'G', None)
+        self.assertFalse(first_ship.crashes_against(second_ship))
+
+    def test_T_shaped_ships_crash(self):
+        first_ship = Navi('first', 5, 'o', 0, 'A', None)
+        second_ship = Navi('second', 5, 'v', 1, 'C', None)
+        self.assertTrue(first_ship.crashes_against(second_ship))

--- a/test_ship.py
+++ b/test_ship.py
@@ -15,7 +15,7 @@ class TestShip(unittest.TestCase):
 
     def test_parallel_horizontal_5len_ships_separated_by_one_row_dont_crash(self):
         first_ship = Navi('first', 5, 'o', 3, 'A', None)
-        second_ship = Navi('second', 5, 'o', 5, 'F', None)
+        second_ship = Navi('second', 5, 'o', 5, 'A', None)
         self.assertFalse(first_ship.crashes_against(second_ship))
 
     def test_completely_overlapped_horizontal_5len_ships_crash(self):


### PR DESCRIPTION
This commit adds some methods and a test suite to test whether two ships crash one against the other. The methods detecting the collision are all belonging to the `Navi` class, since collision depends only on the relative ships' positioning. So far, methods are empty and must be implemented by the students.

The test suite tests various forms of collision and collision-free configurations.

After successfully implementing the methods (i.e. all tests passing), the detection must be integrated into the existing code. The detection routine should be called on every new ship creation, testing collision against all the other ships already added to the field. The `crashes_against()` method should use the `__get_boundaries()` and `__get_used_cells()` **private** methods in order to easily carry out his job.

Note that this commit does not break the existing code. Therefore, the pull request can be safely accepted.